### PR TITLE
Add outputs for IAM role arn and name

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -1,3 +1,11 @@
 output "lambda_arn" {
   value = "${aws_lambda_function.lambda.arn}"
 }
+
+output "role_arn" {
+  value = "${aws_iam_role.lambda.arn}"
+}
+
+output "role_name" {
+  value = "${aws_iam_role.lambda.name}"
+}


### PR DESCRIPTION
As this module creates an IAM role for the lambda function, provide the name and arn of the role as outputs for use. One use case for example would be attaching pre-existing or AWS Managed Policies to the created role:

```
resource "aws_iam_role_policy_attachment" "lambda_basic_exec_attach" {
  role       = "${module.lambda_scheduled.role_name}"
  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
}
resource "aws_iam_role_policy_attachment" "lambda_eni_mgmt_attach" {
  role       = "${module.lambda_scheduled.role_name}"
  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaENIManagementAccess"
}
```