### PR TITLE
Upgrade to 0.12 syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ Module Input Variables
 - `schedule_expression` - a [valid rate or cron expression](http://docs.aws.amazon.com/lambda/latest/dg/tutorial-scheduled-events-schedule-expressions.html)
 - `iam_policy_document` - a valid IAM policy document used for the Lambda's [execution role](http://docs.aws.amazon.com/lambda/latest/dg/intro-permission-model.html#lambda-intro-execution-role)
 - `timeout` - (optional) the amount of time your Lambda Function has to run in seconds. Defaults to 3. See [Limits](https://docs.aws.amazon.com/lambda/latest/dg/limits.html)
-- `subnet_ids` (optional) - If set, the lambda will be deployed inside a VPC on the subnet(s) specified. Expects a comma separated list of valid AWS subnet ids.
-- `security_group_ids` (optional) - If set, the lambda will be deployed inside a VPC and use the security groups specified. Expects a comma separated list of valid VPC security group ids .
+- `vpc_config` (optional) - If set, the lambda will be deployed inside a VPC. It must be a map with the following keys:
+  - `subnet_ids` - A list of valid AWS subnet ids.
+  - `security_group_ids` - A list of valid VPC security group ids.
 - `enabled` - boolean expression. If false, the lambda function and the cloudwatch schedule are not set. Defaults to `true`.
 
 Usage 

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,7 @@
+locals {
+  enabled_as_count = var.enabled ? 1 : 0
+}
+
 resource "aws_iam_role" "lambda" {
   name = var.lambda_name
 
@@ -33,7 +37,7 @@ resource "aws_lambda_function" "lambda" {
   role             = aws_iam_role.lambda.arn
   handler          = var.handler
   source_code_hash = var.source_code_hash
-  count            = var.enabled
+  count            = local.enabled_as_count
   timeout          = var.timeout
 
   dynamic "vpc_config" {
@@ -51,18 +55,18 @@ resource "aws_lambda_permission" "cloudwatch" {
   function_name = aws_lambda_function.lambda[0].arn
   principal     = "events.amazonaws.com"
   source_arn    = aws_cloudwatch_event_rule.lambda[0].arn
-  count         = var.enabled
+  count         = local.enabled_as_count
 }
 
 resource "aws_cloudwatch_event_rule" "lambda" {
   name                = var.lambda_name
   schedule_expression = var.schedule_expression
-  count               = var.enabled
+  count               = local.enabled_as_count
 }
 
 resource "aws_cloudwatch_event_target" "lambda" {
   target_id = var.lambda_name
   rule      = aws_cloudwatch_event_rule.lambda[0].name
   arn       = aws_lambda_function.lambda[0].arn
-  count     = var.enabled
+  count     = local.enabled_as_count
 }

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "lambda" {
-  name = "${var.lambda_name}"
+  name = var.lambda_name
 
   assume_role_policy = <<EOF
 {
@@ -16,49 +16,50 @@ resource "aws_iam_role" "lambda" {
   ]
 }
 EOF
+
 }
 
 resource "aws_iam_role_policy" "lambda" {
-  name = "${var.lambda_name}"
-  role = "${aws_iam_role.lambda.name}"
+  name = var.lambda_name
+  role = aws_iam_role.lambda.name
 
-  policy = "${var.iam_policy_document}"
+  policy = var.iam_policy_document
 }
 
 resource "aws_lambda_function" "lambda" {
-  runtime          = "${var.runtime}"
-  filename         = "${var.lambda_zipfile}"
-  function_name    = "${var.lambda_name}"
-  role             = "${aws_iam_role.lambda.arn}"
-  handler          = "${var.handler}"
-  source_code_hash = "${var.source_code_hash}"
-  count            = "${var.enabled}"
-  timeout          = "${var.timeout}"
+  runtime          = var.runtime
+  filename         = var.lambda_zipfile
+  function_name    = var.lambda_name
+  role             = aws_iam_role.lambda.arn
+  handler          = var.handler
+  source_code_hash = var.source_code_hash
+  count            = var.enabled
+  timeout          = var.timeout
 
   vpc_config {
-    subnet_ids         = ["${var.subnet_ids}"]
-    security_group_ids = ["${var.security_group_ids}"]
+    subnet_ids         = var.subnet_ids
+    security_group_ids = var.security_group_ids
   }
 }
 
 resource "aws_lambda_permission" "cloudwatch" {
   statement_id  = "AllowExecutionFromCloudWatch"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.lambda.arn}"
+  function_name = aws_lambda_function.lambda[0].arn
   principal     = "events.amazonaws.com"
-  source_arn    = "${aws_cloudwatch_event_rule.lambda.arn}"
-  count         = "${var.enabled}"
+  source_arn    = aws_cloudwatch_event_rule.lambda[0].arn
+  count         = var.enabled
 }
 
 resource "aws_cloudwatch_event_rule" "lambda" {
-  name                = "${var.lambda_name}"
-  schedule_expression = "${var.schedule_expression}"
-  count               = "${var.enabled}"
+  name                = var.lambda_name
+  schedule_expression = var.schedule_expression
+  count               = var.enabled
 }
 
 resource "aws_cloudwatch_event_target" "lambda" {
-  target_id = "${var.lambda_name}"
-  rule      = "${aws_cloudwatch_event_rule.lambda.name}"
-  arn       = "${aws_lambda_function.lambda.arn}"
-  count     = "${var.enabled}"
+  target_id = var.lambda_name
+  rule      = aws_cloudwatch_event_rule.lambda[0].name
+  arn       = aws_lambda_function.lambda[0].arn
+  count     = var.enabled
 }

--- a/main.tf
+++ b/main.tf
@@ -36,9 +36,12 @@ resource "aws_lambda_function" "lambda" {
   count            = var.enabled
   timeout          = var.timeout
 
-  vpc_config {
-    subnet_ids         = var.subnet_ids
-    security_group_ids = var.security_group_ids
+  dynamic "vpc_config" {
+    for_each = var.vpc_config == null ? [] : [var.vpc_config]
+    content {
+      subnet_ids         = vpc_config.value.subnet_ids
+      security_group_ids = vpc_config.value.security_group_ids
+    }
   }
 }
 

--- a/output.tf
+++ b/output.tf
@@ -1,11 +1,11 @@
 output "lambda_arn" {
-  value = "${aws_lambda_function.lambda.arn}"
+  value = aws_lambda_function.lambda[0].arn
 }
 
 output "role_arn" {
-  value = "${aws_iam_role.lambda.arn}"
+  value = aws_iam_role.lambda.arn
 }
 
 output "role_name" {
-  value = "${aws_iam_role.lambda.name}"
+  value = aws_iam_role.lambda.name
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,16 +1,23 @@
-variable "lambda_name" {}
+variable "lambda_name" {
+}
 
-variable "runtime" {}
+variable "runtime" {
+}
 
-variable "lambda_zipfile" {}
+variable "lambda_zipfile" {
+}
 
-variable "source_code_hash" {}
+variable "source_code_hash" {
+}
 
-variable "handler" {}
+variable "handler" {
+}
 
-variable "schedule_expression" {}
+variable "schedule_expression" {
+}
 
-variable "iam_policy_document" {}
+variable "iam_policy_document" {
+}
 
 variable "enabled" {
   default = true

--- a/variables.tf
+++ b/variables.tf
@@ -27,10 +27,7 @@ variable "timeout" {
   default = 3
 }
 
-variable "subnet_ids" {
-  default = []
-}
-
-variable "security_group_ids" {
-  default = []
+variable "vpc_config" {
+  type = object({subnet_ids = list(string), security_group_ids = list(string)})
+  default = null
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Not much to add to the PR title except for the admission that I have not tested with a VPC-enabled function.

Breaking change: `subnet_ids` and `security_group_ids` are now nested under `vpc_config`.